### PR TITLE
Fix % normal-mode command

### DIFF
--- a/vimbundle.symlink
+++ b/vimbundle.symlink
@@ -1,6 +1,7 @@
 hashrocket/vim-hashrocket
 AndrewRadev/splitjoin.vim
 adamlowe/vim-slurper
+adelarsq/vim-matchit
 duff/vim-bufonly
 ervandew/supertab
 godlygeek/tabular


### PR DESCRIPTION
The latest tpope/vim-sensible breaks the % (find-matching-bracket) command
unless you also install adelarsq/vim-matchit.